### PR TITLE
feature/CLOWDER-10_common-lib-to-help-with-generator-creation_post-ci-integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           echo "$MY_CIRCLECI_NPM_TOKEN_CLOWDER_UTILS" > ~/.npmrc
       - run: |
           npm install
-          npm build
+          npm run build
           npm publish
 
 #==============================================================================


### PR DESCRIPTION
miss run on npm call
